### PR TITLE
chore: set .nvmrc (lts/hydrogen)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v18
+lts/hydrogen


### PR DESCRIPTION
Zmienia `.nvmrc` na codename `lts/hydrogen`.

konwersja z 'v18' -> codename.

Dzięki temu `nvm use` automatycznie dobiera właściwą linię Node dla repo.